### PR TITLE
Fix compatibility with newer versions of IDEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'fr.ft.aviscogl'
-version '0.2'
+version '0.2.1'
 
 sourceCompatibility = 1.8
 
@@ -27,4 +27,5 @@ patchPluginXml {
 
     changeNotes """
       New version of 42 Header"""
+    untilBuild '2019.3'
 }


### PR DESCRIPTION
I tried installing the version 0.2.0 of this plugin with a CLion 2020.3 . It didn't work because this IDE was not supported by the plugin.

It turns out it is not a compatibility issue, it's juste that this plugin refused to work because of the configuration file.

This PR has been tested with CLion 2020.3, 2019.3 and IntlliJ Idea 2019.3 and it worked fine every time.